### PR TITLE
Fix: Add dbus connection recovery logic to SystemdMonitor

### DIFF
--- a/simpmon/monitor.py
+++ b/simpmon/monitor.py
@@ -321,6 +321,11 @@ class DBusConnectionManager:
             DBusConnectionManager._bus = dbus.SystemBus()
         return DBusConnectionManager._bus
 
+    @staticmethod
+    def reset_connection() -> None:
+        """Clear the cached dbus connection to force reconnection on next use."""
+        DBusConnectionManager._bus = None
+
 
 class SystemdMonitor(Monitor):
     def __init__(self, config: config.SystemdMonitorConfig):
@@ -339,7 +344,8 @@ class SystemdMonitor(Monitor):
         )
 
     def get_datapoint(self, must_exit: threading.Event) -> float:
-        try:
+        def _query_service_state() -> float:
+            """Query the service state via dbus."""
             unit_name = f"{self.service_name}.service"
             unit = self.systemd_proxy.GetUnit(unit_name)
             unit_object = DBusConnectionManager.get_connection().get_object(
@@ -359,9 +365,26 @@ class SystemdMonitor(Monitor):
             elif active_state == "failed":
                 return 2
             raise TypeError(f"Unexpected service state: {active_state}")
+
+        try:
+            return _query_service_state()
         except dbus.DBusException as e:
-            print(f"Error retrieving status for service '{self.service_name}': {e}")
-            return 1  # Assume stopped if there was an error
+            # dbus connection may have gone stale. Log it, reset the cached connection,
+            # reinitialize the proxy, and retry once.
+            logger.warning(
+                f"DBus error querying service '{self.service_name}': {e}. "
+                f"Attempting to reconnect and retry."
+            )
+            DBusConnectionManager.reset_connection()
+            self._initialize_proxy()
+            try:
+                return _query_service_state()
+            except dbus.DBusException as retry_error:
+                logger.error(
+                    f"Retry failed for service '{self.service_name}': {retry_error}. "
+                    f"Assuming service is stopped."
+                )
+                return 1
 
     @property
     def unit(self) -> str:

--- a/simpmon/monitor.py
+++ b/simpmon/monitor.py
@@ -343,31 +343,31 @@ class SystemdMonitor(Monitor):
             systemd_object, dbus_interface="org.freedesktop.systemd1.Manager"
         )
 
+    def _query_service_state(self) -> float:
+        """Query the service state via dbus."""
+        unit_name = f"{self.service_name}.service"
+        unit = self.systemd_proxy.GetUnit(unit_name)
+        unit_object = DBusConnectionManager.get_connection().get_object(
+            "org.freedesktop.systemd1", str(unit)
+        )
+        unit_properties = dbus.Interface(
+            unit_object, dbus_interface="org.freedesktop.DBus.Properties"
+        )
+
+        active_state = unit_properties.Get(
+            "org.freedesktop.systemd1.Unit", "ActiveState"
+        )
+        if active_state == "active":
+            return 0
+        elif active_state == "inactive":
+            return 1
+        elif active_state == "failed":
+            return 2
+        raise TypeError(f"Unexpected service state: {active_state}")
+
     def get_datapoint(self, must_exit: threading.Event) -> float:
-        def _query_service_state() -> float:
-            """Query the service state via dbus."""
-            unit_name = f"{self.service_name}.service"
-            unit = self.systemd_proxy.GetUnit(unit_name)
-            unit_object = DBusConnectionManager.get_connection().get_object(
-                "org.freedesktop.systemd1", str(unit)
-            )
-            unit_properties = dbus.Interface(
-                unit_object, dbus_interface="org.freedesktop.DBus.Properties"
-            )
-
-            active_state = unit_properties.Get(
-                "org.freedesktop.systemd1.Unit", "ActiveState"
-            )
-            if active_state == "active":
-                return 0
-            elif active_state == "inactive":
-                return 1
-            elif active_state == "failed":
-                return 2
-            raise TypeError(f"Unexpected service state: {active_state}")
-
         try:
-            return _query_service_state()
+            return self._query_service_state()
         except dbus.DBusException as e:
             # dbus connection may have gone stale. Log it, reset the cached connection,
             # reinitialize the proxy, and retry once.
@@ -378,7 +378,7 @@ class SystemdMonitor(Monitor):
             DBusConnectionManager.reset_connection()
             self._initialize_proxy()
             try:
-                return _query_service_state()
+                return self._query_service_state()
             except dbus.DBusException as retry_error:
                 logger.error(
                     f"Retry failed for service '{self.service_name}': {retry_error}. "


### PR DESCRIPTION
Fixes #1

When the dbus connection becomes stale (after a dbus service restart or similar), all SystemdMonitor queries fail silently and return 1 (stopped) for all services, causing false simultaneous alerts.

## Changes

- Add `DBusConnectionManager.reset_connection()` to clear the cached bus connection
- Add retry logic to `SystemdMonitor.get_datapoint()`:
  - Catch dbus.DBusException on first attempt
  - Log the error as a warning
  - Clear the cached dbus connection
  - Reinitialize the systemd proxy
  - Retry the query once with the fresh connection
  - Log as error and return 1 only if retry also fails
- Replace `print()` with proper logging to simpmon logs

## Evidence

From pihole logs on 2026-03-20 00:09:33, all six systemd services reported as stopped simultaneously:

```
sshd status -- Alarm status changed ... current alarm is Stopped
unattended-upgrades status -- Alarm status changed ... current alarm is Stopped
pihole status -- Alarm status changed ... current alarm is Stopped
wireguard status -- Alarm status changed ... current alarm is Stopped
rsyslog status -- Alarm status changed ... current alarm is Stopped
```

This indicates a dbus connection issue, not actual service failures.